### PR TITLE
[ fix ] generating config file from another directory

### DIFF
--- a/src/util/generate_voice_conf.py
+++ b/src/util/generate_voice_conf.py
@@ -234,8 +234,8 @@ def generate_template(folder, fp, lang):
         write_line(fp, 'BeginBody', level=2)
         print(f'Reading {subdir}...')
         cnt = 0
-        for subfiles in os.listdir(subdir):
-            if os.path.isfile(os.path.join(subdir, subfiles)) and '.' in subfiles:
+        for subfiles in os.listdir(os.path.join(folder, subdir)):
+            if os.path.isfile(os.path.join(folder, subdir, subfiles)) and '.' in subfiles:
                 cnt += 1
                 name, ftype = subfiles.split('.')
                 write_body(fp, name, ftype, lang)


### PR DESCRIPTION
Fix a bug.

Additional note: The test script in `tests` will identify itself as a audio file. This is by design. We need to separate scripts from audio datasets and thus we can make assumption about the content and the structure under a dataset directory. 

**The script assumes the directory that you are to parse a template configuration file from does not contain any additional things (redundant files) other than audio files**